### PR TITLE
use artifice instead of webmock for blacklist request mocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,11 @@ PATH
   remote: .
   specs:
     conduit-braintree (0.1.12)
+      artifice (~> 0.6)
+      artifice-passthru (~> 0.1.1)
       braintree (~> 2.29.0)
       conduit (~> 0.6.0)
       multi_json (~> 1.10.1)
-      webmock (~> 1.19.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,16 +37,19 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
     arel (5.0.1.20140414130214)
-    aws-sdk (2.0.46)
-      aws-sdk-resources (= 2.0.46)
-    aws-sdk-core (2.0.46)
+    artifice (0.6)
+      rack-test
+    artifice-passthru (0.1.1)
+      artifice
+    aws-sdk (2.0.47)
+      aws-sdk-resources (= 2.0.47)
+    aws-sdk-core (2.0.47)
       builder (~> 3.0)
       jmespath (~> 1.0)
       multi_json (~> 1.0)
-    aws-sdk-resources (2.0.46)
-      aws-sdk-core (= 2.0.46)
+    aws-sdk-resources (2.0.47)
+      aws-sdk-core (= 2.0.47)
     braintree (2.29.0)
       builder (>= 2.0.0)
     builder (3.2.2)
@@ -54,8 +58,6 @@ GEM
       aws-sdk
       excon
       tilt
-    crack (0.4.2)
-      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     excon (0.45.3)
@@ -103,7 +105,6 @@ GEM
     rspec-mocks (3.1.2)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.1)
-    safe_yaml (1.0.4)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     sprockets (2.12.2)
@@ -120,9 +121,6 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    webmock (1.19.0)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
 
 PLATFORMS
   ruby

--- a/conduit-braintree.gemspec
+++ b/conduit-braintree.gemspec
@@ -23,10 +23,11 @@ Gem::Specification.new do |s|
 
   # Dependencies
   #
-  s.add_dependency 'conduit',    '~> 0.6.0'
-  s.add_dependency 'multi_json', '~> 1.10.1'
-  s.add_dependency 'braintree',  '~> 2.29.0'
-  s.add_dependency 'webmock',    '~> 1.19.0'
+  s.add_dependency 'conduit',           '~> 0.6.0'
+  s.add_dependency 'multi_json',        '~> 1.10.1'
+  s.add_dependency 'braintree',         '~> 2.29.0'
+  s.add_dependency 'artifice',          '~> 0.6'
+  s.add_dependency 'artifice-passthru', '~> 0.1.1'
 
   # Development Dependencies
   #

--- a/lib/conduit/braintree/request_mocker/delete_credit_card.rb
+++ b/lib/conduit/braintree/request_mocker/delete_credit_card.rb
@@ -4,14 +4,11 @@ module Conduit::Braintree::RequestMocker
   class DeleteCreditCard < Base
     def mock
       if @mock_status == :failure
-        @stub = stub_request(:any, /braintree/).
-          to_return(body: nil, status: 404, headers: {})
+        @status = 404
       elsif @mock_status == :success
-        @stub = stub_request(:any, /braintree/).
-          to_return(body: nil, status: 200, headers: {})
-      else
-        super
+        @status = 200
       end
+      super
     end
   end
 end

--- a/lib/conduit/braintree/request_mocker/find_customer.rb
+++ b/lib/conduit/braintree/request_mocker/find_customer.rb
@@ -2,13 +2,5 @@ require 'conduit/braintree/request_mocker/base'
 
 module Conduit::Braintree::RequestMocker
   class FindCustomer < Base
-    def mock
-      if @mock_status == :failure
-        @stub = stub_request(:any, /braintree/).
-          to_return(body: nil, status: 404, headers: {})
-      else
-        super
-      end
-    end
   end
 end


### PR DESCRIPTION
This uses [artifice](https://github.com/wycats/artifice) instead of [webmock](https://github.com/bblimke/webmock) to avoid the effect of blocking all HTTP requests unless explicitly allowed, i.e. whitelist. In this case, we block requests to braintree and we allow all other requests to pass through (using [artifice-passthru](https://github.com/tpope/artifice-passthru) ) for a blacklist approach.