### PR TITLE
send back processor/gateway errors to clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (0.1.13)
+    conduit-braintree (1.0.0)
       artifice (~> 0.6)
       artifice-passthru (~> 0.1.1)
       braintree (~> 2.29.0)
@@ -42,25 +42,23 @@ GEM
       rack-test
     artifice-passthru (0.1.1)
       artifice
-    aws-sdk (2.0.47)
-      aws-sdk-resources (= 2.0.47)
-    aws-sdk-core (2.0.47)
-      builder (~> 3.0)
+    aws-sdk (2.1.8)
+      aws-sdk-resources (= 2.1.8)
+    aws-sdk-core (2.1.8)
       jmespath (~> 1.0)
-      multi_json (~> 1.0)
-    aws-sdk-resources (2.0.47)
-      aws-sdk-core (= 2.0.47)
+    aws-sdk-resources (2.1.8)
+      aws-sdk-core (= 2.1.8)
     braintree (2.29.0)
       builder (>= 2.0.0)
     builder (3.2.2)
-    conduit (0.6.0)
+    conduit (0.6.2)
       activesupport
       aws-sdk
       excon
       tilt
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    excon (0.45.3)
+    excon (0.45.4)
     hike (1.2.3)
     i18n (0.7.0)
     jmespath (1.0.2)
@@ -131,3 +129,6 @@ DEPENDENCIES
   rspec
   rspec-its
   shoulda-matchers
+
+BUNDLED WITH
+   1.10.5

--- a/lib/conduit/braintree/json/transaction.rb
+++ b/lib/conduit/braintree/json/transaction.rb
@@ -15,9 +15,14 @@ module Conduit::Driver::Braintree
           attributes
 
         attr_names.inject({}) do |h, attr_name|
-          transaction_attr = attr_name.to_s.gsub(/transaction_/, '')
+          if attr_name =~ /transaction/
+            transaction_attr = attr_name.to_s.gsub(/transaction_/, '')
 
-          h.merge(transaction_attr => response.transaction.send(transaction_attr))
+            h.merge(transaction_attr => response.transaction.send(transaction_attr))
+          else
+            value = response.respond_to?(attr_name) ? response.send(attr_name) : nil
+            h.merge(attr_name.to_s => value)
+          end
         end
       end
     end

--- a/lib/conduit/braintree/parsers/authorize_transaction.rb
+++ b/lib/conduit/braintree/parsers/authorize_transaction.rb
@@ -19,6 +19,9 @@ module Conduit::Driver::Braintree
       object_path('transaction/status')
     end
 
+    attribute :message do
+      object_path('transaction/message')
+    end
   end
 end
 

--- a/lib/conduit/braintree/request_mocker/base.rb
+++ b/lib/conduit/braintree/request_mocker/base.rb
@@ -83,11 +83,11 @@ module Conduit::Braintree::RequestMocker
     end
 
     def response
-      if [:success, :failure, :error].include?(@mock_status)
+      if @mock_status
         return error_response if @mock_status == :error
         render_response
       else
-        raise(ArgumentError, "Mock status must be :success, :failure, or :error")
+        raise(ArgumentError, "Mock status must be set (:success, :failure, or :error for example)")
       end
     end
 

--- a/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/gateway_failure.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/gateway_failure.xml.erb
@@ -1,0 +1,145 @@
+<xml version="1.0" encoding="UTF-8"?>
+<api-error-response>
+  <errors>
+    <errors type="array"/>
+  </errors>
+  <params>
+    <transaction>
+      <amount>4002</amount>
+      <payment-method-token>fgpt7w</payment-method-token>
+      <type>sale</type>
+    </transaction>
+  </params>
+  <message>Gateway Rejected: fraud</message>
+  <transaction>
+    <id>bjrhf4</id>
+    <status>gateway_rejected</status>
+    <type>sale</type>
+    <currency-iso-code>USD</currency-iso-code>
+    <amount>4002.00</amount>
+    <merchant-account-id>hellolabs</merchant-account-id>
+    <order-id nil="true"/>
+    <created-at type="datetime">2015-07-28T17:56:15Z</created-at>
+    <updated-at type="datetime">2015-07-28T17:56:15Z</updated-at>
+    <customer>
+      <id>hello-test</id>
+      <first-name>Corey</first-name>
+      <last-name>Purcell</last-name>
+      <company>Hello Labs</company>
+      <email>corey.purcell@hellolabs.com</email>
+      <website></website>
+      <phone></phone>
+      <fax></fax>
+    </customer>
+    <billing>
+      <id>kp</id>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code>94107</postal-code>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </billing>
+    <refund-id nil="true"/>
+    <refund-ids type="array"/>
+    <refunded-transaction-id nil="true"/>
+    <settlement-batch-id nil="true"/>
+    <shipping>
+      <id nil="true"/>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code nil="true"/>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </shipping>
+    <custom-fields/>
+    <avs-error-response-code nil="true"/>
+    <avs-postal-code-response-code nil="true"/>
+    <avs-street-address-response-code nil="true"/>
+    <cvv-response-code nil="true"/>
+    <gateway-rejection-reason>fraud</gateway-rejection-reason>
+    <processor-authorization-code nil="true"/>
+    <processor-response-code></processor-response-code>
+    <processor-response-text>Unknown ()</processor-response-text>
+    <additional-processor-response nil="true"/>
+    <voice-referral-number nil="true"/>
+    <purchase-order-number nil="true"/>
+    <tax-amount nil="true"/>
+    <tax-exempt type="boolean">false</tax-exempt>
+    <credit-card>
+      <token>fgpt7w</token>
+      <bin>400011</bin>
+      <last-4>1511</last-4>
+      <card-type>Visa</card-type>
+      <expiration-month>04</expiration-month>
+      <expiration-year>2015</expiration-year>
+      <customer-location>US</customer-location>
+      <cardholder-name></cardholder-name>
+      <image-url>https://assets.braintreegateway.com/payment_method_logo/visa.png?environment=sandbox</image-url>
+      <prepaid>Unknown</prepaid>
+      <healthcare>Unknown</healthcare>
+      <debit>Unknown</debit>
+      <durbin-regulated>Unknown</durbin-regulated>
+      <commercial>Unknown</commercial>
+      <payroll>Unknown</payroll>
+      <issuing-bank>Unknown</issuing-bank>
+      <country-of-issuance>Unknown</country-of-issuance>
+      <product-id>Unknown</product-id>
+      <unique-number-identifier>b6d2a7c22df4b8b1f722dc39f2643a20</unique-number-identifier>
+      <venmo-sdk type="boolean">false</venmo-sdk>
+    </credit-card>
+    <status-history type="array">
+      <status-event>
+        <timestamp type="datetime">2015-07-28T17:56:15Z</timestamp>
+        <status>gateway_rejected</status>
+        <amount>4002.00</amount>
+        <user>coreypurcell</user>
+        <transaction-source>api</transaction-source>
+      </status-event>
+    </status-history>
+    <plan-id nil="true"/>
+    <subscription-id nil="true"/>
+    <subscription>
+      <billing-period-end-date nil="true"/>
+      <billing-period-start-date nil="true"/>
+    </subscription>
+    <add-ons type="array"/>
+    <discounts type="array"/>
+    <descriptor>
+      <name nil="true"/>
+      <phone nil="true"/>
+      <url nil="true"/>
+    </descriptor>
+    <recurring type="boolean">false</recurring>
+    <channel nil="true"/>
+    <service-fee-amount nil="true"/>
+    <escrow-status nil="true"/>
+    <disbursement-details>
+      <disbursement-date nil="true"/>
+      <settlement-amount nil="true"/>
+      <settlement-currency-iso-code nil="true"/>
+      <settlement-currency-exchange-rate nil="true"/>
+      <funds-held nil="true"/>
+      <success nil="true"/>
+    </disbursement-details>
+    <disputes type="array"/>
+    <payment-instrument-type>credit_card</payment-instrument-type>
+    <processor-settlement-response-code></processor-settlement-response-code>
+    <processor-settlement-response-text></processor-settlement-response-text>
+    <three-d-secure-info nil="true"/>
+  </transaction>
+</api-error-response>
+

--- a/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/processor_failure.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/processor_failure.xml.erb
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api-error-response>
+  <errors>
+    <errors type="array"/>
+  </errors>
+  <params>
+    <transaction>
+      <amount>2002</amount>
+      <payment-method-token>8kv24g</payment-method-token>
+      <type>sale</type>
+    </transaction>
+  </params>
+  <message>Limit Exceeded</message>
+  <transaction>
+    <id>6x845p</id>
+    <status>processor_declined</status>
+    <type>sale</type>
+    <currency-iso-code>USD</currency-iso-code>
+    <amount>2002.00</amount>
+    <merchant-account-id>hellolabs</merchant-account-id>
+    <order-id nil="true"/>
+    <created-at type="datetime">2015-07-28T17:14:13Z</created-at>
+    <updated-at type="datetime">2015-07-28T17:14:13Z</updated-at>
+    <customer>
+      <id>hello-test</id>
+      <first-name>Corey</first-name>
+      <last-name>Purcell</last-name>
+      <company>Hello Labs</company>
+      <email>corey.purcell@hellolabs.com</email>
+      <website></website>
+      <phone></phone>
+      <fax></fax>
+    </customer>
+    <billing>
+      <id>kp</id>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code>94107</postal-code>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </billing>
+    <refund-id nil="true"/>
+    <refund-ids type="array"/>
+    <refunded-transaction-id nil="true"/>
+    <settlement-batch-id nil="true"/>
+    <shipping>
+      <id nil="true"/>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code nil="true"/>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </shipping>
+    <custom-fields/>
+    <avs-error-response-code nil="true"/>
+    <avs-postal-code-response-code>M</avs-postal-code-response-code>
+    <avs-street-address-response-code>I</avs-street-address-response-code>
+    <cvv-response-code>I</cvv-response-code>
+    <gateway-rejection-reason nil="true"/>
+    <processor-authorization-code nil="true"/>
+    <processor-response-code>2002</processor-response-code>
+    <processor-response-text>Limit Exceeded</processor-response-text>
+    <additional-processor-response>2002 : Limit Exceeded</additional-processor-response>
+    <voice-referral-number nil="true"/>
+    <purchase-order-number nil="true"/>
+    <tax-amount nil="true"/>
+    <tax-exempt type="boolean">false</tax-exempt>
+    <credit-card>
+      <token>8kv24g</token>
+      <bin>401288</bin>
+      <last-4>1881</last-4>
+      <card-type>Visa</card-type>
+      <expiration-month>12</expiration-month>
+      <expiration-year>2020</expiration-year>
+      <customer-location>US</customer-location>
+      <cardholder-name nil="true"/>
+      <image-url>https://assets.braintreegateway.com/payment_method_logo/visa.png?environment=sandbox</image-url>
+      <prepaid>No</prepaid>
+      <healthcare>Unknown</healthcare>
+      <debit>Unknown</debit>
+      <durbin-regulated>Unknown</durbin-regulated>
+      <commercial>Unknown</commercial>
+      <payroll>Unknown</payroll>
+      <issuing-bank>Unknown</issuing-bank>
+      <country-of-issuance>USA</country-of-issuance>
+      <product-id>Unknown</product-id>
+      <unique-number-identifier>95a2266e6ba3b8e765c6e266fc5030cf</unique-number-identifier>
+      <venmo-sdk type="boolean">false</venmo-sdk>
+    </credit-card>
+    <status-history type="array">
+      <status-event>
+        <timestamp type="datetime">2015-07-28T17:14:13Z</timestamp>
+        <status>processor_declined</status>
+        <amount>2002.00</amount>
+        <user>coreypurcell</user>
+        <transaction-source>api</transaction-source>
+      </status-event>
+    </status-history>
+    <plan-id nil="true"/>
+    <subscription-id nil="true"/>
+    <subscription>
+      <billing-period-end-date nil="true"/>
+      <billing-period-start-date nil="true"/>
+    </subscription>
+    <add-ons type="array"/>
+    <discounts type="array"/>
+    <descriptor>
+      <name nil="true"/>
+      <phone nil="true"/>
+      <url nil="true"/>
+    </descriptor>
+    <recurring type="boolean">false</recurring>
+    <channel nil="true"/>
+    <service-fee-amount nil="true"/>
+    <escrow-status nil="true"/>
+    <disbursement-details>
+      <disbursement-date nil="true"/>
+      <settlement-amount nil="true"/>
+      <settlement-currency-iso-code nil="true"/>
+      <settlement-currency-exchange-rate nil="true"/>
+      <funds-held nil="true"/>
+      <success nil="true"/>
+    </disbursement-details>
+    <disputes type="array"/>
+    <payment-instrument-type>credit_card</payment-instrument-type>
+    <processor-settlement-response-code></processor-settlement-response-code>
+    <processor-settlement-response-text></processor-settlement-response-text>
+    <three-d-secure-info nil="true"/>
+  </transaction>
+</api-error-response>

--- a/lib/conduit/braintree/request_mocker/fixtures/settle_transaction/settlement_failure.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/settle_transaction/settlement_failure.xml.erb
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api-error-response>
+  <errors>
+    <errors type="array"/>
+  </errors>
+  <params>
+    <transaction>
+      <amount>4006</amount>
+    </transaction>
+    <action>submit_for_settlement</action>
+    <controller>transactions</controller>
+    <merchant-id>hzgs6hj828fgrrxg</merchant-id>
+    <id>2b3jgt</id>
+  </params>
+  <message>Settlement amount is too large.</message>
+  <transaction>
+    <id>2b3jgt</id>
+    <status>authorized</status>
+    <type>sale</type>
+    <currency-iso-code>USD</currency-iso-code>
+    <amount>4002.00</amount>
+    <merchant-account-id>hellolabs</merchant-account-id>
+    <order-id></order-id>
+    <created-at type="datetime">2015-07-28T18:17:41Z</created-at>
+    <updated-at type="datetime">2015-07-28T18:17:42Z</updated-at>
+    <customer>
+      <id>hello-test</id>
+      <first-name>Corey</first-name>
+      <last-name>Purcell</last-name>
+      <company>Hello Labs</company>
+      <email>corey.purcell@hellolabs.com</email>
+      <website></website>
+      <phone></phone>
+      <fax></fax>
+    </customer>
+    <billing>
+      <id>nr</id>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code>20000</postal-code>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </billing>
+    <refund-id nil="true"/>
+    <refund-ids type="array"/>
+    <refunded-transaction-id nil="true"/>
+    <settlement-batch-id nil="true"/>
+    <shipping>
+      <id nil="true"/>
+      <first-name nil="true"/>
+      <last-name nil="true"/>
+      <company nil="true"/>
+      <street-address nil="true"/>
+      <extended-address nil="true"/>
+      <locality nil="true"/>
+      <region nil="true"/>
+      <postal-code nil="true"/>
+      <country-name nil="true"/>
+      <country-code-alpha2 nil="true"/>
+      <country-code-alpha3 nil="true"/>
+      <country-code-numeric nil="true"/>
+    </shipping>
+    <custom-fields/>
+    <avs-error-response-code nil="true"/>
+    <avs-postal-code-response-code>N</avs-postal-code-response-code>
+    <avs-street-address-response-code>I</avs-street-address-response-code>
+    <cvv-response-code>I</cvv-response-code>
+    <gateway-rejection-reason nil="true"/>
+    <processor-authorization-code>1R2J3W</processor-authorization-code>
+    <processor-response-code>1000</processor-response-code>
+    <processor-response-text>Approved</processor-response-text>
+    <additional-processor-response nil="true"/>
+    <voice-referral-number nil="true"/>
+    <purchase-order-number></purchase-order-number>
+    <tax-amount nil="true"/>
+    <tax-exempt type="boolean">false</tax-exempt>
+    <credit-card>
+      <token>8kv24g</token>
+      <bin>401288</bin>
+      <last-4>1881</last-4>
+      <card-type>Visa</card-type>
+      <expiration-month>12</expiration-month>
+      <expiration-year>2020</expiration-year>
+      <customer-location>US</customer-location>
+      <cardholder-name></cardholder-name>
+      <image-url>https://assets.braintreegateway.com/payment_method_logo/visa.png?environment=sandbox</image-url>
+      <prepaid>No</prepaid>
+      <healthcare>Unknown</healthcare>
+      <debit>Unknown</debit>
+      <durbin-regulated>Unknown</durbin-regulated>
+      <commercial>Unknown</commercial>
+      <payroll>Unknown</payroll>
+      <issuing-bank>Unknown</issuing-bank>
+      <country-of-issuance>USA</country-of-issuance>
+      <product-id>Unknown</product-id>
+      <unique-number-identifier>95a2266e6ba3b8e765c6e266fc5030cf</unique-number-identifier>
+      <venmo-sdk type="boolean">false</venmo-sdk>
+    </credit-card>
+    <status-history type="array">
+      <status-event>
+        <timestamp type="datetime">2015-07-28T18:17:42Z</timestamp>
+        <status>authorized</status>
+        <amount>4002.00</amount>
+        <user>coreypurcell</user>
+        <transaction-source>control_panel</transaction-source>
+      </status-event>
+    </status-history>
+    <plan-id nil="true"/>
+    <subscription-id nil="true"/>
+    <subscription>
+      <billing-period-end-date nil="true"/>
+      <billing-period-start-date nil="true"/>
+    </subscription>
+    <add-ons type="array"/>
+    <discounts type="array"/>
+    <descriptor>
+      <name nil="true"/>
+      <phone nil="true"/>
+      <url nil="true"/>
+    </descriptor>
+    <recurring type="boolean">false</recurring>
+    <channel nil="true"/>
+    <service-fee-amount nil="true"/>
+    <escrow-status nil="true"/>
+    <disbursement-details>
+      <disbursement-date nil="true"/>
+      <settlement-amount nil="true"/>
+      <settlement-currency-iso-code nil="true"/>
+      <settlement-currency-exchange-rate nil="true"/>
+      <funds-held nil="true"/>
+      <success nil="true"/>
+    </disbursement-details>
+    <disputes type="array"/>
+    <payment-instrument-type>credit_card</payment-instrument-type>
+    <processor-settlement-response-code></processor-settlement-response-code>
+    <processor-settlement-response-text></processor-settlement-response-text>
+    <risk-data>
+      <id>3Z7S0GPNKGWG</id>
+      <decision>Approve</decision>
+    </risk-data>
+    <three-d-secure-info nil="true"/>
+  </transaction>
+</api-error-response>

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '0.1.13'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/actions/authorize_transaction_spec.rb
+++ b/spec/actions/authorize_transaction_spec.rb
@@ -41,6 +41,20 @@ describe Conduit::Driver::Braintree::AuthorizeTransaction do
       end
     end
 
+    context 'with a processor failure' do
+      let(:mock_status)        { 'processor_failure' }
+      it "returns a failure message" do
+        expect(subject.message).to eql "Limit Exceeded"
+      end
+    end
+
+    context 'with a processor failure' do
+      let(:mock_status)        { 'gateway_failure' }
+      it "returns a failure message" do
+        expect(subject.message).to eql "Gateway Rejected: fraud"
+      end
+    end
+
     context 'without a merchant_account_id' do
       let(:options) do
         { merchant_id: 'hello-labs-1',

--- a/spec/actions/settle_transaction_spec.rb
+++ b/spec/actions/settle_transaction_spec.rb
@@ -38,5 +38,12 @@ describe Conduit::Driver::Braintree::SettleTransaction do
         should eql expected
       end
     end
+
+    context 'with a settlement failure' do
+      let(:mock_status)        { 'settlement_failure' }
+      it "returns a failure message" do
+        expect(subject.message).to eql "Settlement amount is too large."
+      end
+    end
   end
 end


### PR DESCRIPTION
We need sensible error messages, which requires us to know why the
processor/gateway rejected the transaction.

Use Parser#message to retreive the message from settle_transaction and
authorize_transaction