### PR TITLE
Resequence the order of assigning verification attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.0.5)
+    conduit-braintree (1.0.6)
       artifice (~> 0.6)
       artifice-passthru (~> 0.1.1)
       braintree (~> 2.29)
@@ -42,16 +42,16 @@ GEM
       rack-test
     artifice-passthru (0.1.1)
       artifice
-    aws-sdk (2.1.15)
-      aws-sdk-resources (= 2.1.15)
-    aws-sdk-core (2.1.15)
+    aws-sdk (2.1.23)
+      aws-sdk-resources (= 2.1.23)
+    aws-sdk-core (2.1.23)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.15)
-      aws-sdk-core (= 2.1.15)
-    braintree (2.47.0)
+    aws-sdk-resources (2.1.23)
+      aws-sdk-core (= 2.1.23)
+    braintree (2.48.1)
       builder (>= 2.0.0)
     builder (3.2.2)
-    conduit (0.6.2)
+    conduit (0.6.3)
       activesupport
       aws-sdk
       excon
@@ -61,8 +61,7 @@ GEM
     excon (0.45.4)
     hike (1.2.3)
     i18n (0.7.0)
-    jmespath (1.0.2)
-      multi_json (~> 1.0)
+    jmespath (1.1.3)
     json (1.8.2)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)

--- a/lib/conduit/braintree/json/verification.rb
+++ b/lib/conduit/braintree/json/verification.rb
@@ -41,12 +41,12 @@ module Conduit::Driver::Braintree
       end
 
       def verification
-        if response.respond_to?(:transaction)
+        if response.respond_to?(:credit_card_verification)
+          response.credit_card_verification
+        elsif response.respond_to?(:transaction)
           response.transaction
         elsif response.respond_to?(:credit_card)
           response.credit_card.verification
-        elsif response.respond_to?(:credit_card_verification)
-          response.credit_card_verification
         end
       end
     end

--- a/lib/conduit/braintree/parsers/create_credit_card.rb
+++ b/lib/conduit/braintree/parsers/create_credit_card.rb
@@ -32,35 +32,35 @@ module Conduit::Driver::Braintree
     end
 
     attribute :avs_error_response_code do
-      object_path('credit_card/avs_error_response_code')
+      object_path('avs_error_response_code')
     end
 
     attribute :avs_postal_code_response_code do
-      object_path('credit_card/avs_postal_code_response_code')
+      object_path('avs_postal_code_response_code')
     end
 
     attribute :avs_street_address_response_code do
-      object_path('credit_card/avs_street_address_response_code')
+      object_path('avs_street_address_response_code')
     end
 
     attribute :cvv_response_code do
-      object_path('credit_card/cvv_response_code')
+      object_path('cvv_response_code')
     end
 
     attribute :gateway_rejection_reason do
-      object_path('credit_card/gateway_rejection_reason')
+      object_path('gateway_rejection_reason')
     end
 
     attribute :processor_response_code do
-      object_path('credit_card/processor_response_code')
+      object_path('processor_response_code')
     end
 
     attribute :processor_response_text do
-      object_path('credit_card/processor_response_text')
+      object_path('processor_response_text')
     end
 
     attribute :verification_status do
-      object_path('credit_card/verification_status')
+      object_path('verification_status')
     end
 
     attribute :message do

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '1.0.5'
+    VERSION = '1.0.6'
   end
 end

--- a/spec/actions/create_credit_card_spec.rb
+++ b/spec/actions/create_credit_card_spec.rb
@@ -16,10 +16,10 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       customer_id:      'k4rs72_1',
       cardholder_name:  'John Doe',
       number:           '4111111111111111',
-      cvv:              '',
+      cvv:              '123',
       expiration_month: 12,
       expiration_year:  2099,
-      billing_address:  {},
+      billing_address:  { street_address: '123 Main St' },
       verification_merchant_account_id: 'TESTIT'
     }
   end

--- a/spec/actions/update_credit_card_spec.rb
+++ b/spec/actions/update_credit_card_spec.rb
@@ -16,10 +16,10 @@ describe Conduit::Driver::Braintree::UpdateCreditCard do
       token:            '24sss2',
       cardholder_name:  'John Doe',
       number:           '4111111111111111',
-      cvv:              '',
+      cvv:              '123',
       expiration_month: 12,
       expiration_year:  2099,
-      billing_address:  {},
+      billing_address:  { street_address: '123 Main St' },
       verification_merchant_account_id: 'TESTIT'
     }
   end
@@ -31,7 +31,8 @@ describe Conduit::Driver::Braintree::UpdateCreditCard do
       environment:      :sandbox,
       mock_status:      mock_status,
       token:            '24sss2',
-      cvv:              '',
+      cvv:              '123',
+      billing_address:  { postal_code: '12345' },
       expiration_month: 12,
       expiration_year:  2099
     }


### PR DESCRIPTION
Checks for 'credit_card_verification' object before 'transaction' or 'credit_card' as the source for verification details.  Also adjusts the CreateCreditCard parser to look for the attributes at the top level of the json rather than layered beneath a credit_card object.

Cleans up specs to be compliant with the latest version of conduit.