### PR TITLE
replace old-and-busted Artifice with webmock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,10 @@ PATH
   remote: .
   specs:
     conduit-braintree (1.0.6)
-      artifice (~> 0.6)
-      artifice-passthru (~> 0.1.1)
       braintree (~> 2.29)
       conduit (~> 0.6.0)
       multi_json (~> 1.10.1)
+      webmock (~> 1.22)
 
 GEM
   remote: https://rubygems.org/
@@ -37,18 +36,15 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
-    artifice (0.6)
-      rack-test
-    artifice-passthru (0.1.1)
-      artifice
-    aws-sdk (2.1.23)
-      aws-sdk-resources (= 2.1.23)
-    aws-sdk-core (2.1.23)
+    aws-sdk (2.2.9)
+      aws-sdk-resources (= 2.2.9)
+    aws-sdk-core (2.2.9)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.23)
-      aws-sdk-core (= 2.1.23)
-    braintree (2.48.1)
+    aws-sdk-resources (2.2.9)
+      aws-sdk-core (= 2.2.9)
+    braintree (2.56.0)
       builder (>= 2.0.0)
     builder (3.2.2)
     conduit (0.6.3)
@@ -56,9 +52,12 @@ GEM
       aws-sdk
       excon
       tilt
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     excon (0.45.4)
+    hashdiff (0.2.3)
     hike (1.2.3)
     i18n (0.7.0)
     jmespath (1.1.3)
@@ -102,6 +101,7 @@ GEM
     rspec-mocks (3.1.2)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.1)
+    safe_yaml (1.0.4)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     sprockets (2.12.2)
@@ -118,6 +118,10 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    webmock (1.22.5)
+      addressable (< 2.4.0)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -128,6 +132,3 @@ DEPENDENCIES
   rspec
   rspec-its
   shoulda-matchers
-
-BUNDLED WITH
-   1.10.6

--- a/conduit-braintree.gemspec
+++ b/conduit-braintree.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'conduit',           '~> 0.6.0'
   s.add_dependency 'multi_json',        '~> 1.10.1'
   s.add_dependency 'braintree',         '~> 2.29'
-  s.add_dependency 'artifice',          '~> 0.6'
-  s.add_dependency 'artifice-passthru', '~> 0.1.1'
+  s.add_dependency 'webmock',           '~> 1.22'
 
   # Development Dependencies
   #

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '1.0.6'
+    VERSION = '1.0.7'
   end
 end


### PR DESCRIPTION
Artifice was bypassing webmock on the reactor tests, so we switched it to use webmock here too.