### PR TITLE
Use new normalized error class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.0.6)
+    conduit-braintree (1.1.0)
       braintree (~> 2.29)
-      conduit (~> 0.6.0)
+      conduit (~> 0.7.0)
       multi_json (~> 1.10.1)
       webmock (~> 1.22)
 
@@ -36,18 +36,19 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     arel (5.0.1.20140414130214)
-    aws-sdk (2.2.9)
-      aws-sdk-resources (= 2.2.9)
-    aws-sdk-core (2.2.9)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.9)
-      aws-sdk-core (= 2.2.9)
-    braintree (2.56.0)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
+    braintree (2.59.0)
       builder (>= 2.0.0)
     builder (3.2.2)
-    conduit (0.6.3)
+    coderay (1.1.1)
+    conduit (0.7.0)
       activesupport
       aws-sdk
       excon
@@ -56,17 +57,24 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    excon (0.45.4)
-    hashdiff (0.2.3)
+    excon (0.49.0)
+    hashdiff (0.3.0)
     hike (1.2.3)
     i18n (0.7.0)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.2)
+    json_pure (1.8.3)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.3)
     minitest (5.5.1)
     multi_json (1.10.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -104,6 +112,7 @@ GEM
     safe_yaml (1.0.4)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
+    slop (3.6.0)
     sprockets (2.12.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -118,8 +127,8 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    webmock (1.22.5)
-      addressable (< 2.4.0)
+    webmock (1.24.3)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
 
@@ -128,7 +137,11 @@ PLATFORMS
 
 DEPENDENCIES
   conduit-braintree!
+  pry
   rails
   rspec
   rspec-its
   shoulda-matchers
+
+BUNDLED WITH
+   1.11.2

--- a/conduit-braintree.gemspec
+++ b/conduit-braintree.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   # Dependencies
   #
-  s.add_dependency 'conduit',           '~> 0.6.0'
+  s.add_dependency 'conduit',           '~> 0.7.0'
   s.add_dependency 'multi_json',        '~> 1.10.1'
   s.add_dependency 'braintree',         '~> 2.29'
   s.add_dependency 'webmock',           '~> 1.22'
@@ -34,5 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'rails'
+  s.add_development_dependency 'pry'
 
 end

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '1.0.7'
+    VERSION = '1.1.0'
   end
 end

--- a/spec/actions/authorize_transaction_spec.rb
+++ b/spec/actions/authorize_transaction_spec.rb
@@ -33,9 +33,10 @@ describe Conduit::Driver::Braintree::AuthorizeTransaction do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          merchant_id: ["Invalid verification merchant account ID (917218)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :merchant_id,
+            message: "Invalid verification merchant account ID (917218)")
+        ]
 
         should eql expected
       end

--- a/spec/actions/create_credit_card_spec.rb
+++ b/spec/actions/create_credit_card_spec.rb
@@ -44,9 +44,10 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          merchant_id: ["Invalid verification merchant account ID (917218)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :merchant_id,
+            message: "Invalid verification merchant account ID (917218)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/create_customer_spec.rb
+++ b/spec/actions/create_customer_spec.rb
@@ -37,7 +37,10 @@ describe Conduit::Driver::Braintree::FindCustomer do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = { base: ["Failed to find resource with identifier f2b5gb_1 (error)"] }
+        expected = [
+          Conduit::Error.new(attribute: :base,
+            message: "Failed to find resource with identifier f2b5gb_1 (error)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/delete_credit_card_spec.rb
+++ b/spec/actions/delete_credit_card_spec.rb
@@ -29,7 +29,10 @@ describe Conduit::Driver::Braintree::DeleteCreditCard do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = { base: ["Failed to find resource with identifier 24sss2 (error)"] }
+        expected = [
+          Conduit::Error.new(attribute: :base,
+            message: "Failed to find resource with identifier 24sss2 (error)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/find_customer_spec.rb
+++ b/spec/actions/find_customer_spec.rb
@@ -32,7 +32,10 @@ describe Conduit::Driver::Braintree::FindCustomer do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = { base: ["Failed to find resource with identifier f2b5gb_1 (error)"] }
+        expected = [
+          Conduit::Error.new(attribute: :base,
+            message: "Failed to find resource with identifier f2b5gb_1 (error)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/refund_transaction_spec.rb
+++ b/spec/actions/refund_transaction_spec.rb
@@ -32,9 +32,10 @@ describe Conduit::Driver::Braintree::RefundTransaction do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          merchant_id: ["Invalid verification merchant account ID (917218)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :merchant_id,
+            message: "Invalid verification merchant account ID (917218)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/settle_transaction_spec.rb
+++ b/spec/actions/settle_transaction_spec.rb
@@ -32,9 +32,10 @@ describe Conduit::Driver::Braintree::SettleTransaction do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          merchant_id: ["Invalid verification merchant account ID (917218)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :merchant_id,
+            message: "Invalid verification merchant account ID (917218)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/update_credit_card_spec.rb
+++ b/spec/actions/update_credit_card_spec.rb
@@ -69,9 +69,10 @@ describe Conduit::Driver::Braintree::UpdateCreditCard do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          base: ["Duplicate card exists (81724)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :base,
+            message: "Duplicate card exists (81724)")
+        ]
         should eql expected
       end
     end

--- a/spec/actions/void_transaction_spec.rb
+++ b/spec/actions/void_transaction_spec.rb
@@ -30,9 +30,10 @@ describe Conduit::Driver::Braintree::VoidTransaction do
       let(:mock_status)        { 'failure' }
       its(:response_status)    { should eql mock_status }
       its(:errors) do
-        expected = {
-          merchant_id: ["Invalid verification merchant account ID (917218)"]
-        }
+        expected = [
+          Conduit::Error.new(attribute: :merchant_id,
+            message: "Invalid verification merchant account ID (917218)")
+        ]
         should eql expected
       end
     end

--- a/spec/parsers/base_spec.rb
+++ b/spec/parsers/base_spec.rb
@@ -24,7 +24,7 @@ describe Conduit::Driver::Braintree::Parser::Base do
       it { should_not be_empty }
       it 'should have an error indicating that it could not be parsed' do
         instance = described_class.new(response_body)
-        expect(instance.errors).to include 'Unable to parse response'
+        expect(instance.errors.map(&:message)).to include 'Unable to parse response'
       end
     end
   end
@@ -54,7 +54,7 @@ describe Conduit::Driver::Braintree::Parser::Base do
     context 'when the errors key points to an array' do
       let(:response_body) { '{"errors":["You bad"],"foo":{"bar": "baz"}}' }
       its(:errors) { should_not be_empty }
-      its(:errors) { should eql ["You bad"] }
+      its(:errors) { should eql [Conduit::Error.new(message: "You bad")] }
     end
   end
 


### PR DESCRIPTION
Use the Conduit::Error class when reporting errors.