### PR TITLE
Add find_transaction driver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.1.1)
+    conduit-braintree (1.1.2)
       braintree (~> 2.29)
       conduit (~> 0.7.0)
       multi_json (~> 1.10.1)

--- a/lib/conduit/braintree/actions/find_transaction.rb
+++ b/lib/conduit/braintree/actions/find_transaction.rb
@@ -1,0 +1,20 @@
+require 'conduit/braintree/json/customer'
+require 'conduit/braintree/actions/base'
+
+module Conduit::Driver::Braintree
+  class FindTransaction < Base
+    required_attributes :reference_number
+
+    private
+
+    def perform_request
+      response = Braintree::Transaction.find(@options[:reference_number])
+      body     = Conduit::Driver::Braintree::Json::Transaction.new(OpenStruct.new(transaction: response)).to_json
+
+      parser = parser_class.new(body)
+      Conduit::ApiResponse.new(raw_response: response, body: body, parser: parser)
+    rescue Braintree::BraintreeError => error
+      report_braintree_exceptions(error)
+    end
+  end
+end

--- a/lib/conduit/braintree/driver.rb
+++ b/lib/conduit/braintree/driver.rb
@@ -17,6 +17,7 @@ module Conduit
       action :void_transaction
       action :settle_transaction
       action :refund_transaction
+      action :find_transaction
 
     end
   end

--- a/lib/conduit/braintree/parsers/find_transaction.rb
+++ b/lib/conduit/braintree/parsers/find_transaction.rb
@@ -1,0 +1,6 @@
+require 'conduit/braintree/parsers/create_customer'
+
+module Conduit::Driver::Braintree
+  class FindTransaction::Parser < AuthorizeTransaction::Parser
+  end
+end

--- a/lib/conduit/braintree/request_mocker/find_transaction.rb
+++ b/lib/conduit/braintree/request_mocker/find_transaction.rb
@@ -1,0 +1,6 @@
+require 'conduit/braintree/request_mocker/base'
+
+module Conduit::Braintree::RequestMocker
+  class FindTransaction < Base
+  end
+end

--- a/lib/conduit/braintree/request_mocker/fixtures/find_transaction/success.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/find_transaction/success.xml.erb
@@ -1,0 +1,7 @@
+  <?xml version="1.0" encoding="UTF-8"?>
+  <transaction>
+    <id><%= reference_number %></id>
+    <type></type>
+    <amount></amount>
+    <status>settled</status>
+  </transaction>

--- a/lib/conduit/braintree/views/find_transaction.erb
+++ b/lib/conduit/braintree/views/find_transaction.erb
@@ -1,0 +1,4 @@
+<%= MultiJson.dump({
+  Id: reference_number,
+  Amount: amount
+  }) %>

--- a/lib/conduit/braintree/views/find_transaction.erb
+++ b/lib/conduit/braintree/views/find_transaction.erb
@@ -1,4 +1,3 @@
 <%= MultiJson.dump({
-  Id: reference_number,
-  Amount: amount
+  Id: reference_number
   }) %>

--- a/spec/actions/find_transaction_spec.rb
+++ b/spec/actions/find_transaction_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'braintree'
+require 'conduit/braintree'
+
+describe Conduit::Driver::Braintree::FindTransaction do
+
+  subject do
+    described_class.new(options).perform.parser
+  end
+
+  let(:options) do
+    { merchant_id:      'hello-labs-1',
+      private_key:      'hello-labs-ssh',
+      public_key:       'hello-world',
+      environment:      :sandbox,
+      reference_number: 'k4rs72',
+      mock_status:      mock_status
+    }
+  end
+
+  describe '#perform' do
+    context 'with a successful authorization' do
+      let(:mock_status)        { 'success' }
+      its(:response_status)    { should eql mock_status }
+    end
+  end
+end

--- a/spec/actions/find_transaction_spec.rb
+++ b/spec/actions/find_transaction_spec.rb
@@ -22,6 +22,7 @@ describe Conduit::Driver::Braintree::FindTransaction do
     context 'with a successful authorization' do
       let(:mock_status)        { 'success' }
       its(:response_status)    { should eql mock_status }
+      its(:transaction_status) { should eql 'settled' }
     end
   end
 end


### PR DESCRIPTION
This code adds a new driver to conduit-braintree to allow us to
find a transaction. It uses the Braintree::Transaction.find() method,
which takes in a parameter of the transaction id or in our case,
the reference number. Once you have the transaction you can check any
of the attributes on it such as the status.

This code also includes a includes adding the driver, adding a test
for the driver and fixtures for the test.