### PR TITLE
Only return one set of error messages.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.1.2)
+    conduit-braintree (1.1.3)
       braintree (~> 2.29)
       conduit (~> 0.7.0)
       multi_json (~> 1.10.1)

--- a/lib/conduit/braintree/parsers/base.rb
+++ b/lib/conduit/braintree/parsers/base.rb
@@ -41,11 +41,17 @@ module Conduit::Driver::Braintree
       def normalized_errors
         return [] if object_path('successful')
 
-        # if it's not successful, sometimes the message is just in the message attribute
-        errors = []
-        errors << Conduit::Error.new(message: object_path('message')) if object_path('message')
+        # if it's not successful, and we have no other error details,
+        # just return the wrapped message
+        if object_path('message') && !detailed_errors?
+          [Conduit::Error.new(message: object_path('message'))]
+        else
+          normalized_error_objects
+        end
+      end
 
-        errors + normalized_error_objects
+      def detailed_errors?
+        !(object_path('errors').nil? || object_path('errors').empty?)
       end
 
       def normalized_error_objects

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
   end
 end


### PR DESCRIPTION
If we have details error messages, then use those, otherwise use the message reported directly from braintree.