### PR TITLE
fix empty mocking that cause a error to happen

### DIFF
--- a/lib/conduit/braintree/request_mocker/base.rb
+++ b/lib/conduit/braintree/request_mocker/base.rb
@@ -45,7 +45,7 @@ module Conduit::Braintree::RequestMocker
             else
               200
             end
-        {status: @status, headers: headers, body: response}
+        {status: @status, headers: headers, body: response || render_empty_response}
       end
     end
 
@@ -67,6 +67,15 @@ module Conduit::Braintree::RequestMocker
       nil
     ensure
       gz && gz.finish
+    end
+
+    def render_empty_response
+      f = StringIO.new("")
+      gz = Zlib::GzipWriter.new(f)
+      gz.write("")
+      f.string
+    ensure
+      gz && gz.finish      
     end
 
     def action_name

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = '1.1.6'
+    VERSION = '1.1.7'
   end
 end

--- a/spec/actions/find_transaction_spec.rb
+++ b/spec/actions/find_transaction_spec.rb
@@ -24,5 +24,18 @@ describe Conduit::Driver::Braintree::FindTransaction do
       its(:response_status)    { should eql mock_status }
       its(:transaction_status) { should eql 'settled' }
     end
+
+    context "with a failure" do
+      let(:mock_status)     { 'failure' }
+      its(:response_status) { should eql mock_status }
+
+      it "should have errors" do
+        expected = [
+          Conduit::Error.new(attribute: :base,
+            message: "Failed to find resource with identifier  (error)")
+        ]
+        expect(subject.errors).to eql expected
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,10 +17,6 @@ Braintree::Configuration.logger.level = Logger::WARN
 # Rspec Configuration
 #
 RSpec.configure do |config|
-  config.before(:suite) do
-    Excon.defaults[:mock] = true
-  end
-
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end


### PR DESCRIPTION
## Ticket

No ticket.

## What this does

Fixes mocking where we did not return a response

## Why we did this

To fix mocking, whats happening is we did not have a fixture for some responses so we would return nil to braintree gem. When braintree trys to debug that message we get a error.
https://github.com/braintree/braintree_ruby/blob/02db6f8d75830aa3338d61985183aab4eebfab9b/lib/braintree/http.rb#L106

We should be atleast returning a empty response so the braintree gem does not blow up since it expects something.

## Overall, I feel this way about this code

Shame, pride, exasperation, glee, relief, exhaustion
