### PR TITLE
Fix braintree error handling

### DIFF
--- a/lib/conduit/braintree/actions/create_payment_method.rb
+++ b/lib/conduit/braintree/actions/create_payment_method.rb
@@ -5,32 +5,44 @@ module Conduit::Driver::Braintree
     # To create a new payment method for an existing customer,
     # the only required attributes are the customer ID and payment method nonce.
     required_attributes :payment_method_nonce, :customer_id
+    attr_accessor :raw_response
 
     private
 
     def perform_request
-      response = Braintree::PaymentMethod.create(whitelist_options)
-      if response.success?
-        credit_card_response = OpenStruct.new(credit_card: response.payment_method)
-        generate_response(credit_card_response, response)
+      @raw_response = Braintree::PaymentMethod.create(whitelist_options)
+      if success?
+        generate_response(credit_card_response)
       else
-        error_response = OpenStruct.new(success?: false, errors: [OpenStruct.new(attribute: :base, code: "error", message: error_message(response))])
-        generate_response(error_response, response)
+        generate_response(error_response)
       end
     rescue Braintree::BraintreeError => error
       report_braintree_exceptions(error)
     end
 
-    def error_message(response)
-      message = response.errors.map { |error| "#{error.code}: #{error.message}" }.join(".")
-      if response.message.present?
+    def success?
+      raw_response.success?
+    end
+
+    def credit_card_response
+      OpenStruct.new(credit_card: raw_response.payment_method)
+    end
+
+    def error_response
+      OpenStruct.new(success?: false, errors: [OpenStruct.new(attribute: :base, code: "error", 
+        message: error_message)])
+    end
+
+    def error_message
+      message = raw_response.errors.map { |error| "#{error.code}: #{error.message}" }.join(".")
+      if raw_response.message.present?
         message.concat(". ") if message.present?
-        message.concat(response.message)
+        message.concat(raw_response.message)
       end
       message
     end
 
-    def generate_response(response_body, raw_response)
+    def generate_response(response_body)
       body = Conduit::Driver::Braintree::Json::CreditCard.new(response_body).to_json
       parser = parser_class.new(body)
       Conduit::ApiResponse.new(raw_response: raw_response, body: body, parser: parser)

--- a/lib/conduit/braintree/actions/create_payment_method.rb
+++ b/lib/conduit/braintree/actions/create_payment_method.rb
@@ -23,10 +23,10 @@ module Conduit::Driver::Braintree
 
     def error_message(response)
       message = response.errors.map { |error| "#{error.code}: #{error.message}" }.join(".")
-        if response.message.present?
-          message.concat(". ") if message.present?
-          message.concat(response.message)
-        end
+      if response.message.present?
+        message.concat(". ") if message.present?
+        message.concat(response.message)
+      end
       message
     end
 

--- a/lib/conduit/braintree/actions/create_payment_method.rb
+++ b/lib/conduit/braintree/actions/create_payment_method.rb
@@ -12,15 +12,28 @@ module Conduit::Driver::Braintree
       response = Braintree::PaymentMethod.create(whitelist_options)
       if response.success?
         credit_card_response = OpenStruct.new(credit_card: response.payment_method)
-        body = Conduit::Driver::Braintree::Json::CreditCard.new(credit_card_response).to_json
-
-        parser = parser_class.new(body)
-        Conduit::ApiResponse.new(raw_response: response, body: body, parser: parser)
+        generate_response(credit_card_response, response)
       else
-        respond_with_error(response.errors.map(&:message).join("."))
+        error_response = OpenStruct.new(success?: false, errors: [OpenStruct.new(attribute: :base, code: "error", message: error_message(response))])
+        generate_response(error_response, response)
       end
     rescue Braintree::BraintreeError => error
       report_braintree_exceptions(error)
+    end
+
+    def error_message(response)
+      message = response.errors.map { |error| "#{error.code}: #{error.message}" }.join(".")
+        if response.message.present?
+          message.concat(". ") if message.present?
+          message.concat(response.message)
+        end
+      message
+    end
+
+    def generate_response(response_body, raw_response)
+      body = Conduit::Driver::Braintree::Json::CreditCard.new(response_body).to_json
+      parser = parser_class.new(body)
+      Conduit::ApiResponse.new(raw_response: raw_response, body: body, parser: parser)
     end
   end
 end

--- a/lib/conduit/braintree/request_mocker/fixtures/create_payment_method/failure.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/create_payment_method/failure.xml.erb
@@ -11,5 +11,6 @@
       </errors>
     </credit-card>
   </errors>
+  <message>Transaction Declined</message>
 </api-error-response>
 

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.2.5".freeze
+    VERSION = "1.2.6".freeze
   end
 end

--- a/spec/actions/create_payment_method_spec.rb
+++ b/spec/actions/create_payment_method_spec.rb
@@ -28,7 +28,7 @@ describe Conduit::Driver::Braintree::CreatePaymentMethod do
       its(:errors) do
         expected = [
           Conduit::Error.new(attribute: :base,
-            message: "Invalid verification merchant account ID (error)")
+            message: "917218: Invalid verification merchant account ID. Transaction Declined (error)")
         ]
         should eql expected
       end


### PR DESCRIPTION
## Ticket

https://jira.bqsoft.com/browse/ATOM-7203

## What this does
Fix error response message, Response will have errors only if there is validation failure, the message contains detailed human readable error description.

## Why we did this
Error response was not showing any message so it was difficult to understand why transaction failed

## I'd like the reviews to pay special attention to:
I'm not sure on whether errors already reported in error section will also be present on message tag. If that's going to be the case then I think we will need changes later to make sure we do not log same error twice