### PR TITLE
Skip fraud detection by default

### DIFF
--- a/lib/conduit/braintree/actions/authorize_transaction.rb
+++ b/lib/conduit/braintree/actions/authorize_transaction.rb
@@ -13,8 +13,13 @@ module Conduit::Driver::Braintree
     # request.
     #
     def perform_request
-      parameters = { amount: @options[:amount],
-                    payment_method_token: @options[:token] }
+      parameters = {
+        amount: @options[:amount],
+        payment_method_token: @options[:token],
+        options: {
+          skip_advanced_fraud_checking: !@options[:enable_fraud_checking]
+        }
+      }
       parameters[:merchant_account_id] = @options[:merchant_account_id] if @options[:merchant_account_id].present?
       parameters[:device_data] = @options[:device_data] if @options[:device_data].present?
 

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.2.7".freeze
+    VERSION = "1.3.0".freeze
   end
 end


### PR DESCRIPTION
We need to enable `skip_advanced_fraud_detection` on `sale` so transaction are not marked as fraud, and permanently blacklisted, if the client enables Braintree's `Advanced Fraud Detection`