### PR TITLE
Add billing address to create credit card and payment actions

### DIFF
--- a/lib/conduit/braintree/json/credit_card.rb
+++ b/lib/conduit/braintree/json/credit_card.rb
@@ -17,6 +17,8 @@ module Conduit::Driver::Braintree
 
           if attr_name == :last_four
             h.merge(attr_name => response.credit_card.last_4)
+          elsif attr_name == :billing_address
+            h.merge(attr_name => billing_address_attributes)
           elsif attr_name == :customer_id
             h.merge(attr_name => response.credit_card.id)
           elsif response.credit_card.respond_to?(attr_name)
@@ -24,6 +26,30 @@ module Conduit::Driver::Braintree
           else
             h.merge(attr_name => nil)
           end
+        end
+      end
+
+      def billing_address_attributes
+        [
+          :company,
+          :country_code_alpha2,
+          :country_code_alpha3,
+          :country_code_numeric,
+          :country_name,
+          :created_at,
+          :customer_id,
+          :extended_address,
+          :first_name,
+          :id,
+          :last_name,
+          :locality,
+          :postal_code,
+          :region,
+          :street_address,
+          :updated_at
+        ].inject({}) do |h, prop|
+          h[prop] = response.credit_card.billing_address.try(prop)
+          h
         end
       end
     end

--- a/lib/conduit/braintree/parsers/create_credit_card.rb
+++ b/lib/conduit/braintree/parsers/create_credit_card.rb
@@ -30,6 +30,10 @@ module Conduit::Driver::Braintree
       object_path("credit_card/bin")
     end
 
+    attribute :billing_address do
+      object_path("credit_card/billing_address")
+    end
+
     attribute :avs_error_response_code do
       object_path("avs_error_response_code")
     end

--- a/lib/conduit/braintree/request_mocker/base.rb
+++ b/lib/conduit/braintree/request_mocker/base.rb
@@ -116,6 +116,14 @@ class MockHelpers
     card_number[-4, 4]
   end
 
+  def postal_code
+    "29650"
+  end
+
+  def street_address
+    "123 Main St"
+  end
+
   private
 
   def card_number

--- a/lib/conduit/braintree/request_mocker/fixtures/create_credit_card/success.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/create_credit_card/success.xml.erb
@@ -7,4 +7,8 @@
   <card-type>Visa</card-type>
   <bin><%= mock.bin %></bin>
   <last-4><%= mock.last_4 %></last-4>
+  <billing-address>
+    <street-address><%= billing_address[:street_address] %></street-address>
+    <postal-code><%= billing_address[:postal_code] %></postal-code>
+  </billing-address>
 </credit-card>

--- a/lib/conduit/braintree/request_mocker/fixtures/create_payment_method/success.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/create_payment_method/success.xml.erb
@@ -7,4 +7,8 @@
   <card-type>Visa</card-type>
   <bin><%= mock.bin %></bin>
   <last-4><%= mock.last_4 %></last-4>
+  <billing-address>
+    <street-address><%= mock.street_address %></street-address>
+    <postal-code><%= mock.postal_code %></postal-code>
+  </billing-address>
 </credit-card>

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.3.0".freeze
+    VERSION = "1.3.1".freeze
   end
 end

--- a/spec/actions/create_credit_card_spec.rb
+++ b/spec/actions/create_credit_card_spec.rb
@@ -17,7 +17,7 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       cvv:              "123",
       expiration_month: 12,
       expiration_year:  2099,
-      billing_address:  { street_address: "123 Main St" },
+      billing_address:  { street_address: "123 Main St", postal_code: "1234" },
       verification_merchant_account_id: "TESTIT" }
   end
 
@@ -35,6 +35,8 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       its(:last_four)         { should eql "1111" }
       its(:token)             { should_not be_empty }
       its(:message)           { should be_nil }
+      its(:billing_address)   { should include(postal_code: "1234") }
+      its(:billing_address)   { should include(street_address: "123 Main St") }
     end
 
     context "with a failure authorizing" do

--- a/spec/actions/create_credit_card_spec.rb
+++ b/spec/actions/create_credit_card_spec.rb
@@ -17,7 +17,7 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       cvv:              "123",
       expiration_month: 12,
       expiration_year:  2099,
-      billing_address:  { street_address: "123 Main St", postal_code: "1234" },
+      billing_address:  { street_address: "321 Main St", postal_code: "12345" },
       verification_merchant_account_id: "TESTIT" }
   end
 
@@ -35,8 +35,8 @@ describe Conduit::Driver::Braintree::CreateCreditCard do
       its(:last_four)         { should eql "1111" }
       its(:token)             { should_not be_empty }
       its(:message)           { should be_nil }
-      its(:billing_address)   { should include(postal_code: "1234") }
-      its(:billing_address)   { should include(street_address: "123 Main St") }
+      its(:billing_address)   { should include(postal_code: "12345") }
+      its(:billing_address)   { should include(street_address: "321 Main St") }
     end
 
     context "with a failure authorizing" do

--- a/spec/actions/create_payment_method_spec.rb
+++ b/spec/actions/create_payment_method_spec.rb
@@ -21,6 +21,8 @@ describe Conduit::Driver::Braintree::CreatePaymentMethod do
     let(:mock_status)       { "success" }
     its(:response_status)   { should eql mock_status }
     its(:token)             { should_not be_empty }
+    its(:billing_address)   { should include(postal_code: "29650") }
+    its(:billing_address)   { should include(street_address: "123 Main St") }
 
     context "with a failure authorizing" do
       let(:mock_status)        { "failure" }


### PR DESCRIPTION
## Ticket

This helps with ATOM-6475

## What this does

Adds `billing_address` fields to the response of `create_credit_card` and `create_payment_method` actions

## Why we did this

We need them for the new braintree JS SDK
