### PR TITLE
pass in http_status

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     conduit-braintree (1.3.3)
       braintree (~> 2.83.0)
-      conduit (~> 1.1.1)
+      conduit (~> 1.1.9)
       multi_json (~> 1.10.1)
       webmock (>= 2.3)
 
@@ -63,7 +63,7 @@ GEM
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    conduit (1.1.8)
+    conduit (1.1.9)
       activesupport
       aws-sdk (~> 2)
       excon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.3.2)
+    conduit-braintree (1.3.3)
       braintree (~> 2.83.0)
       conduit (~> 1.1.1)
       multi_json (~> 1.10.1)

--- a/conduit-braintree.gemspec
+++ b/conduit-braintree.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # Dependencies
   #
   s.add_dependency "braintree",  "~> 2.83.0"
-  s.add_dependency "conduit",    "~> 1.1.1"
+  s.add_dependency "conduit",    "~> 1.1.9"
   s.add_dependency "multi_json", "~> 1.10.1"
   s.add_dependency "webmock",    ">= 2.3"
 

--- a/lib/conduit/braintree/parsers/base.rb
+++ b/lib/conduit/braintree/parsers/base.rb
@@ -5,7 +5,7 @@ module Conduit::Driver::Braintree
     class Base < Conduit::Core::Parser
       attr_reader :json, :http_status
 
-      def initialize(response_body, http_status: nil)
+      def initialize(response_body, http_status = nil)
         response_body ||= "{}"
         @json = MultiJson.load(response_body, symbolize_keys: true)
         @http_status = http_status

--- a/lib/conduit/braintree/parsers/base.rb
+++ b/lib/conduit/braintree/parsers/base.rb
@@ -3,11 +3,12 @@ require "multi_json"
 module Conduit::Driver::Braintree
   module Parser
     class Base < Conduit::Core::Parser
-      attr_reader :json
+      attr_reader :json, :http_status
 
-      def initialize(response_body)
+      def initialize(response_body, http_status: nil)
         response_body ||= "{}"
         @json = MultiJson.load(response_body, symbolize_keys: true)
+        @http_status = http_status
       rescue MultiJson::ParseError
         @json = { errors: ["Unable to parse response"] }
       end

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.3.2".freeze
+    VERSION = "1.3.3".freeze
   end
 end


### PR DESCRIPTION
## Ticket

https://jira.bqsoft.com/browse/ATOM-7598

## What this does

Allow to pass in http_status

## Why we did this

So atom can start passing this in, certain conduit drivers need it
