### PR TITLE
Atom 7702 move error type to conduit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.3.5)
+    conduit-braintree (1.3.6)
       braintree (~> 2.83.0)
       conduit (~> 1.1.9)
       multi_json (~> 1.10.1)
@@ -80,7 +80,7 @@ GEM
     hashdiff (0.3.7)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/lib/conduit/braintree/parsers/base.rb
+++ b/lib/conduit/braintree/parsers/base.rb
@@ -3,6 +3,23 @@ require "multi_json"
 module Conduit::Driver::Braintree
   module Parser
     class Base < Conduit::Core::Parser
+      HARD_ERROR_CODES = [
+       "2004", "2005", "2006", "2007", "2008",
+       "2010", "2011", "2012", "2013", "2014",
+       "2015", "2017", "2018", "2019", "2020",
+       "2022", "2023", "2024", "2027", "2028",
+       "2029", "2030", "2031", "2032", "2036",
+       "2037", "2039", "2041", "2043", "2044",
+       "2045", "2047", "2049", "2051", "2053",
+       "2055", "2056", "2058", "2059", "2060",
+       "2061", "2063", "2064", "2065", "2066",
+       "2067", "2068", "2069", "2070", "2071",
+       "2072", "2073", "2074", "2075", "2076",
+       "2077", "2079", "2081", "2082", "2083",
+       "2084", "2085", "2086", "2087", "2088",
+       "2089", "2090", "2091"
+      ].freeze
+
       attr_reader :json, :http_status
 
       def initialize(response_body, http_status = nil)
@@ -16,6 +33,16 @@ module Conduit::Driver::Braintree
       def response_status
         data = json
         object_path("successful") ? "success" : "failure"
+      end
+
+      def error_type
+        return if object_path("successful")
+        hard_error_message? ? "hard" : "soft"
+      end
+
+      def hard_error_message?
+        msg = errors.map(&:message).join(",")
+        HARD_ERROR_CODES.any? { |code| msg.match?(code) }
       end
 
       # Returns a hash of errors reported by Braintree

--- a/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/gateway_failure.xml.erb
+++ b/lib/conduit/braintree/request_mocker/fixtures/authorize_transaction/gateway_failure.xml.erb
@@ -72,7 +72,7 @@
     <cvv-response-code nil="true"/>
     <gateway-rejection-reason>fraud</gateway-rejection-reason>
     <processor-authorization-code nil="true"/>
-    <processor-response-code>9999</processor-response-code>
+    <processor-response-code>2004</processor-response-code>
     <processor-response-text>Unknown ()</processor-response-text>
     <additional-processor-response nil="true"/>
     <voice-referral-number nil="true"/>

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.3.5".freeze
+    VERSION = "1.3.6".freeze
   end
 end

--- a/spec/actions/authorize_transaction_spec.rb
+++ b/spec/actions/authorize_transaction_spec.rb
@@ -43,13 +43,15 @@ describe Conduit::Driver::Braintree::AuthorizeTransaction do
       let(:mock_status) { "processor_failure" }
       it "returns a failure message" do
         expect(subject.message).to eql "Limit Exceeded (2002)"
+        expect(subject.error_type).to eql "soft"
       end
     end
 
     context "with a processor failure" do
       let(:mock_status) { "gateway_failure" }
       it "returns a failure message" do
-        expect(subject.message).to eql "Gateway Rejected: fraud (9999)"
+        expect(subject.message).to eql "Gateway Rejected: fraud (2004)"
+        expect(subject.error_type).to eql "hard"
       end
     end
 
@@ -82,6 +84,7 @@ describe Conduit::Driver::Braintree::AuthorizeTransaction do
           options: { skip_advanced_fraud_checking: true }
         ).and_call_original
         expect(subject.transaction_status).to eql "authorized"
+        expect(subject.error_type).to eql nil
       end
     end
 


### PR DESCRIPTION
## Ticket

https://jira.bqsoft.com/browse/ATOM-7702

## What this does

Moves error_type handling to conduit driver

## Why we did this

Makes sense for conduit layer to do this instead of atom
