### PR TITLE
Pass device_data to Braintree

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-braintree (1.3.9)
+    conduit-braintree (1.4.0)
       braintree (~> 2.83.0)
       conduit (~> 1.1.9)
       multi_json (~> 1.10.1)

--- a/lib/conduit/braintree/actions/base.rb
+++ b/lib/conduit/braintree/actions/base.rb
@@ -14,6 +14,7 @@ module Conduit::Driver::Braintree
 
     def initialize(options)
       super(options)
+      expand_device_data
       configure_braintree
     end
 
@@ -102,6 +103,11 @@ module Conduit::Driver::Braintree
 
     def mock_mode?
       @options.key?(:mock_status)
+    end
+
+    def expand_device_data
+      return unless @options[:device_data].is_a?(Hash)
+      @options.merge!(@options.delete(:device_data))
     end
   end
 end

--- a/lib/conduit/braintree/actions/base.rb
+++ b/lib/conduit/braintree/actions/base.rb
@@ -10,6 +10,8 @@ module Conduit::Driver::Braintree
         *Conduit::Driver::Braintree.optional_attributes
     end
 
+    attr_accessor :options
+
     def initialize(options)
       super(options)
       configure_braintree
@@ -33,11 +35,11 @@ module Conduit::Driver::Braintree
 
     def perform_action
       if mock_mode?
-         mocker = request_mocker.new(self, @options)
-         mocker.with_mocking { perform_request }
-       else
-         perform_request
-       end
+        mocker = request_mocker.new(self, @options)
+        mocker.with_mocking { perform_request }
+      else
+        perform_request
+      end
     end
 
     def report_braintree_exceptions(exception)

--- a/lib/conduit/braintree/actions/create_payment_method.rb
+++ b/lib/conduit/braintree/actions/create_payment_method.rb
@@ -7,15 +7,9 @@ module Conduit::Driver::Braintree
 
     attr_accessor :raw_response
 
-    def expand_device_data
-      return unless @options[:device_data].is_a?(Hash)
-      @options.merge!(@options.delete(:device_data))
-    end
-
     private
 
     def perform_request
-      expand_device_data
       @raw_response = Braintree::PaymentMethod.create(whitelist_options)
       if success?
         generate_body(credit_card_response)

--- a/lib/conduit/braintree/version.rb
+++ b/lib/conduit/braintree/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Braintree
-    VERSION = "1.3.9".freeze
+    VERSION = "1.4.0".freeze
   end
 end

--- a/spec/actions/create_payment_method_spec.rb
+++ b/spec/actions/create_payment_method_spec.rb
@@ -20,17 +20,21 @@ describe Conduit::Driver::Braintree::CreatePaymentMethod do
 
   subject { described_class.new(options) }
 
-  describe "#expand_device_data" do
+  context "expanding device_data" do
     context "when device_data is a string" do
       it "keeps device_data in options" do
         options[:device_data] = "somestring"
-        expect { subject.expand_device_data }.not_to change { subject.options }
+        expect(subject.options.key?(:device_data)).to eql(true)
+        expect(subject.options.key?(:device_session_id)).to eql(false)
+        expect(subject.options.key?(:fraud_merchant_id)).to eql(false)
       end
     end
 
     context "when device_data is a hash" do
-      it "keeps device_data in options" do
-        expect { subject.expand_device_data }.to change { subject.options }
+      it "replaces device_data with child params" do
+        expect(subject.options.key?(:device_data)).to eql(false)
+        expect(subject.options.key?(:device_session_id)).to eql(true)
+        expect(subject.options.key?(:fraud_merchant_id)).to eql(true)
       end
     end
   end

--- a/spec/actions/create_payment_method_spec.rb
+++ b/spec/actions/create_payment_method_spec.rb
@@ -1,24 +1,43 @@
 require "spec_helper"
 
 describe Conduit::Driver::Braintree::CreatePaymentMethod do
-  subject do
-    described_class.new(options).perform.parser
-  end
-
+  let(:mock_status) { "success" }
   let(:options) do
     {
-      merchant_id:      "hello-labs-1",
-      private_key:      "hello-labs-ssh",
-      public_key:       "hello-world",
-      environment:      :sandbox,
-      mock_status:      mock_status,
+      merchant_id:          "hello-labs-1",
+      private_key:          "hello-labs-ssh",
+      public_key:           "hello-world",
+      environment:          :sandbox,
+      mock_status:          mock_status,
       payment_method_nonce: "Sid and Noncy",
-      customer_id: "customer-1"
+      customer_id:          "customer-1",
+      device_data: {
+        device_session_id: "572da92539d8c567182a1ef139ea498c",
+        fraud_merchant_id: "600000"
+      }
     }
   end
 
+  subject { described_class.new(options) }
+
+  describe "#expand_device_data" do
+    context "when device_data is a string" do
+      it "keeps device_data in options" do
+        options[:device_data] = "somestring"
+        expect { subject.expand_device_data }.not_to change { subject.options }
+      end
+    end
+
+    context "when device_data is a hash" do
+      it "keeps device_data in options" do
+        expect { subject.expand_device_data }.to change { subject.options }
+      end
+    end
+  end
+
   describe "#perform" do
-    let(:mock_status)       { "success" }
+    subject { described_class.new(options).perform.parser }
+
     its(:response_status)   { should eql mock_status }
     its(:token)             { should_not be_empty }
     its(:billing_address)   { should include(postal_code: "29650") }


### PR DESCRIPTION
## What this does

Forwards along device_data to Braintree, but also translates a nested hash to what Braintree lib expects.

## Why we did this

To support kount device data collection.
